### PR TITLE
Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ branding:
   icon: list
   color: purple
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
I noticed some of my workflows keep displaying the following warning annotation:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: knicknic/os-specific-run@v1.0.3. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The above link describes the issue in more detail, and includes some pointers about what to do about it. The fix seemed like a trivial version bump, and I decided to send this quick PR about it.

Please review and merge, or let me know how to improve it!